### PR TITLE
Service discovery features

### DIFF
--- a/jsonrpcbase/exceptions.py
+++ b/jsonrpcbase/exceptions.py
@@ -4,9 +4,8 @@ Exception classes
 
 
 class JSONRPCBaseError(RuntimeError):
-    def __init__(self, name):
-        self.name = name
-        self.message = f"Duplicate method name for JSON-RPC service: '{self.name}'"
+    def __init__(self, message):
+        self.message = message
         super().__init__(self.message)
 
     def __str__(self):
@@ -14,13 +13,20 @@ class JSONRPCBaseError(RuntimeError):
 
 
 class InvalidSchemaError(JSONRPCBaseError):
+    """Invalid JSON-Schema data."""
     pass
 
 
-class InvalidServerErrorCode(RuntimeError):
-    # TODO make custom message and inherit from JSONRPCBaseError
-    message = "Invalid server error code; must be in the range -32000 to -32099."
+class InvalidServerErrorCode(JSONRPCBaseError):
+    """Invalid custom server error code (must be -32000 - -32099)."""
+    pass
 
 
 class DuplicateMethodName(JSONRPCBaseError):
+    """User tried to register two methods of the same name to the same service."""
+    pass
+
+
+class InvalidFileType(JSONRPCBaseError):
+    """Invalid file extension"""
     pass

--- a/jsonrpcbase/main.py
+++ b/jsonrpcbase/main.py
@@ -190,7 +190,10 @@ class JSONRPCService(object):
         params = req_data.get('params')
         (params_schema, result_schema) = utils.get_method_schemas(self.schema, req_data['method'])
         # Validate the parameters with the json-schema, if present
-        if params_schema is None and params is not None:
+        if (req_data['method'] in self.schema['definitions']['methods']
+                and params_schema is None
+                and params is not None):
+            # If there is an entry for the method, but no params schema, then params must be absent
             err_data = {'details': "Parameters not allowed"}
             return self._err_response(-32602, req_data, err_data)
         elif params_schema is not None:

--- a/jsonrpcbase/main.py
+++ b/jsonrpcbase/main.py
@@ -165,9 +165,10 @@ class JSONRPCService(object):
             jsonschema.validate(req_data, REQUEST_SCHEMA)
         except jsonschema.exceptions.ValidationError as err:
             log.exception(f'Invalid JSON-RPC request for {req_data}: {err}')
-            return self._err_response(-32600, req_data,
-                                      err_data={'details': err.message},
-                                      always_respond=True)
+            data = {
+                'details': err.message,
+            }
+            return self._err_response(-32600, req_data, err_data=data, always_respond=True)
         # Handle unknown method error
         if req_data['method'] not in self.method_data:
             # Missing method
@@ -185,7 +186,7 @@ class JSONRPCService(object):
                 jsonschema.validate(params, schema)
             except jsonschema.exceptions.ValidationError as err:
                 # Invalid params error response
-                err_data = {'details': err.message}
+                err_data = {'details': err.message, 'path': list(err.path)}
                 return self._err_response(-32602, req_data, err_data)
         try:
             result = method(params, metadata)

--- a/jsonrpcbase/types.py
+++ b/jsonrpcbase/types.py
@@ -1,0 +1,34 @@
+from typing import Dict, List, Optional, Union, Callable, NamedTuple
+
+
+class ServiceInfo(NamedTuple):
+    """
+    Metadata about the whole service.
+    """
+    title: str
+    description: str
+    version: str
+
+
+class Method(NamedTuple):
+    """
+    Method function handler, and any other metadata we may need in the future
+    """
+    method: Callable
+
+
+# Mapping of method name to a namedtuple of handler function and anything else we need
+MethodData = Dict[str, Method]
+
+# RPC ID field
+Identifier = Optional[Union[int, str]]
+# RPC params or result field
+ParamsResult = Optional[Union[dict, list]]
+
+# Request structure
+MethodRequest = Union[dict, List[dict]]
+
+# Result structure for a JSON-RPC 2.0 request
+# Will be None if the request was a notification
+# Will be a list of results if request was batch
+MethodResult = Optional[Union[dict, List[dict]]]

--- a/jsonrpcbase/utils.py
+++ b/jsonrpcbase/utils.py
@@ -70,6 +70,8 @@ def load_schema(schema: Union[str, dict]) -> dict:
     if 'rpc.discover' in schema['definitions']['methods']:
         msg = "The `rpc.discover` method is reserved and should not be used"
         raise exceptions.InvalidSchemaError(msg)
+    # Builtin method schemas
+    schema['definitions']['methods']['rpc.discover'] = {}
     return schema
 
 

--- a/jsonrpcbase/utils.py
+++ b/jsonrpcbase/utils.py
@@ -1,8 +1,9 @@
-import jsonschema
 import json
-import yaml
+import jsonschema
 import os
-from typing import Optional, Any, List
+import yaml
+
+from typing import Optional, Any, List, Union
 
 import jsonrpcbase.exceptions as exceptions
 
@@ -26,30 +27,96 @@ def get_path(obj: Any, path: List[str]) -> Optional[Any]:
     return obj
 
 
-def load_schema(path: str) -> dict:
+def load_yaml_or_json(path: str) -> dict:
+    """
+    Load yaml or json data from a file path into a python object
+    """
+    ext = os.path.splitext(path)[1].lower()
+    if ext == '.yaml' or ext == '.yml':
+        with open(path) as fd:
+            ret = yaml.safe_load(fd)
+    elif ext == '.json':
+        with open(path) as fd:
+            ret = json.load(fd)
+    else:
+        msg = f'File at path {path} must be YAML or JSON; {ext} is invalid'
+        raise exceptions.InvalidFileType(msg)
+    return ret
+
+
+def load_schema(schema: Union[str, dict]) -> dict:
     """
     Load, parse, and validate a JSON-Schema from a YAML or JSON file path.
 
     Args:
-        path: file path to a JSON or YAML file
+        schema: dict of schema or file path to a JSON or YAML file
     Returns:
         An in-memory, jsonschema-validated python object
 
     throws InvalidSchemaError
     """
-    ext = os.path.splitext(path)[1].lower()
-    if ext == '.yaml' or ext == '.yml':
-        with open(path) as fd:
-            schema = yaml.safe_load(fd)
-    elif ext == '.json':
-        with open(path) as fd:
-            schema = json.load(fd)
-    else:
-        msg = f'Service schema must be YAML or JSON; {ext} is invalid'
-        raise exceptions.InvalidSchemaError(msg)
+    if isinstance(schema, str):
+        schema = load_yaml_or_json(schema)
+    elif schema is None:
+        schema = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+        }
     # Validate the schema
     jsonschema.Draft7Validator.check_schema(schema)
-    if 'definitions' not in schema:
-        msg = "No 'definitions' property found for the service schema"
+    # Set some defaults
+    schema['definitions'] = schema.get('definitions', {})
+    schema['definitions']['methods'] = schema['definitions'].get('methods', {})
+    # Set service discovery schema
+    if 'rpc.discover' in schema['definitions']['methods']:
+        msg = "The `rpc.discover` method is reserved and should not be used"
         raise exceptions.InvalidSchemaError(msg)
     return schema
+
+
+def load_service_info(service_info: Union[dict, str]):
+    """Load the service info data, possibly from a file path."""
+    if isinstance(service_info, dict):
+        info = service_info
+    if isinstance(service_info, str):
+        info = load_yaml_or_json(service_info)
+    jsonschema.validate(info, {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["title", "version", "description"],
+        "properties": {
+            "title": {"type": "string"},
+            "version": {"type": "string"},
+            "description": {"type": "string"},
+        }
+    })
+    return info
+
+
+def get_method_schemas(schema: dict, method_name: str):
+    """
+    Get the params and result schema for a given method by name from the
+    service schema.
+    """
+    params_path = ['definitions', 'methods', method_name, 'params']
+    result_path = ['definitions', 'methods', method_name, 'result']
+    params = get_path(schema, params_path)
+    result = get_path(schema, result_path)
+    # Clone the data so it can be safely mutated
+    params = dict(params) if params is not None else params
+    result = dict(result) if result is not None else result
+    return (params, result)
+
+
+def response_id(req_data):
+    """
+    Get the ID for the response from a JSON-RPC request
+    Return None if ID is missing or invalid
+    """
+    _id = None
+    if isinstance(req_data, dict):
+        _id = req_data.get('id')
+    if type(_id) in (str, int):
+        return _id
+    else:
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kbase_jsonrpcbase"
-version = "0.3.0-alpha3"
+version = "0.3.0-alpha4"
 description = "Simple JSON-RPC service without transport layer"
 authors = []
 license = "MIT"

--- a/test/service.json
+++ b/test/service.json
@@ -1,0 +1,5 @@
+{
+  "title": "Test service",
+  "description": "Test service description",
+  "version": "0.1.0-alpha1"
+}

--- a/test/test_jsonrpcbase.py
+++ b/test/test_jsonrpcbase.py
@@ -601,8 +601,6 @@ def test_service_discovery_ok():
     assert res['result']['service_info'] == info
 
 
-# TODO invalid service discovery params
-
 def test_service_discovery_invalid_params():
     """
     Test valid service discovery response.
@@ -616,6 +614,10 @@ def test_service_discovery_invalid_params():
     assert res['jsonrpc'] == '2.0'
     assert res['id'] == 0
     assert 'result' not in res
+    print(res)
+    assert res['error']['message'] == 'Invalid params'
+    assert res['error']['code'] == -32602
+    assert res['error']['data']['details'] == 'Parameters not allowed'
 
 
 def test_service_info():

--- a/test/test_schema.yaml
+++ b/test/test_schema.yaml
@@ -23,9 +23,8 @@ definitions:
         maxLength: 1
         items: {type: integer}
     noop:
-      params: {type: [array, object, "null"]}
-    broken_func:
-      params: {type: [array, object, "null"]}
+      params: {type: [array, object]}
+    broken_func: {}
     posv:
       # Positional array types test
       params: {"$ref": "#/definitions/test_array"}

--- a/test/test_schema.yaml
+++ b/test/test_schema.yaml
@@ -3,6 +3,29 @@ $schema: http://json-schema.org/draft-07/schema
 title: Test service schema
 definitions:
   methods:
+    subtract:
+      params:
+        type: array
+        minLength: 2
+        maxLength: 2
+        items: {type: integer}
+    kwargs_subtract:
+      params:
+        type: object
+        required: [a, b]
+        properties:
+          a: {type: integer}
+          b: {type: integer}
+    square:
+      params:
+        type: array
+        minLength: 1
+        maxLength: 1
+        items: {type: integer}
+    noop:
+      params: {type: [array, object, "null"]}
+    broken_func:
+      params: {type: [array, object, "null"]}
     posv:
       # Positional array types test
       params: {"$ref": "#/definitions/test_array"}


### PR DESCRIPTION
* Clean up / fix error classes
* Add service info (metadata like name, desc, version)
* Allow loading schema from in-memory dict as well as path
* Strengthen and expand some of the type declarations and usage
* Add rule to enforce params to be absent if the method is present in the schema but has no params schema
* Generalize some of the schema loading code
* Add method to handle the "rpc.discover" method, which shows information about the service, including schema and service info (name/desc/version)
